### PR TITLE
Fix: 메인 페이지 상품 리스트 렌더링 조건 #13

### DIFF
--- a/src/js/components/ProductList.js
+++ b/src/js/components/ProductList.js
@@ -3,8 +3,8 @@ import useHttp from "../utils/useHttp.js";
 import "../../css/components/productList.css";
 
 export default class ProductList {
-    constructor($main) {
-        if (!$main) {
+    constructor($productList) {
+        if (!$productList) {
             this.render();
         }
     }

--- a/src/js/views/Home.js
+++ b/src/js/views/Home.js
@@ -11,12 +11,12 @@ export default class Home extends AbstractView {
         this.$app = $("#app");
         this.$header = $(".topbar", this.$app);
         this.$footer = $(".footer", this.$app);
-        this.$main = $(".main", this.$app);
+        this.$productList = $(".product-list", this.$app);
     }
 
     render() {
         new Topbar(this.$header);
         new Footer(this.$footer);
-        new ProductList(this.$main);
+        new ProductList(this.$productList);
     }
 }


### PR DESCRIPTION
* 기존: .main이 없을 때 상품 리스트를 .main 내 렌더링하는 것으로 함
* 기존 방식의 문제점: 만약 사용자가 회원 가입 페이지만 다른 사람한테 공유받아, 처음 보는 페이지가 회원 가입 페이지라고 하자. 그러면 회원 가입 페이지에는 .main이 있을거임. 그럼 위의 조건대로라면, 이미 .main이 있기 때문에 메인 페이지로 다시 옮겨도 상품 리스트가 렌더링 되지 못함
* 해결: .main -> .main 내 .product-list가 없으면 상품 리스트를 렌더링하는 것으로